### PR TITLE
(#14) Modifying .gitattributes to force LF line ending on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*	text eol=lf


### PR DESCRIPTION
This is for #14

I modified `.gitattributes` to force LF line endings and avoid problems with Qulice on Windows.