### PR TITLE
(#45) Refactoring fields in TkNotifications and TkThread

### DIFF
--- a/src/main/java/com/g4s8/ghman/App.java
+++ b/src/main/java/com/g4s8/ghman/App.java
@@ -18,6 +18,7 @@ package com.g4s8.ghman;
 
 import com.g4s8.ghman.bot.BotApp;
 import com.g4s8.ghman.data.FlywayDataSource;
+import com.g4s8.ghman.data.PgUsers;
 import com.g4s8.ghman.data.SimpleDataSource;
 import com.g4s8.ghman.web.WebApp;
 import com.jcabi.log.VerboseRunnable;
@@ -65,7 +66,7 @@ public final class App {
                 new BotApp(
                     System.getenv("TG_NAME"),
                     System.getenv("TG_TOKEN"),
-                    data
+                    new PgUsers(data)
                 )
             )
         );

--- a/src/main/java/com/g4s8/ghman/bot/BotApp.java
+++ b/src/main/java/com/g4s8/ghman/bot/BotApp.java
@@ -16,7 +16,7 @@
  */
 package com.g4s8.ghman.bot;
 
-import com.g4s8.ghman.data.PgUsers;
+import com.g4s8.ghman.user.Users;
 import com.g4s8.teletakes.bot.BotSimple;
 import com.g4s8.teletakes.fk.FkCallbackQuery;
 import com.g4s8.teletakes.fk.FkCommand;
@@ -25,7 +25,6 @@ import com.g4s8.teletakes.tk.TkFork;
 import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
 import java.util.regex.Pattern;
-import javax.sql.DataSource;
 import org.telegram.telegrambots.ApiContextInitializer;
 import org.telegram.telegrambots.TelegramBotsApi;
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
@@ -62,21 +61,21 @@ public final class BotApp implements Runnable {
     private final TelegramBotsApi api;
 
     /**
-     * Data source.
+     * Users.
      */
-    private final DataSource data;
+    private final Users users;
 
     /**
      * Ctor.
      * @param name Bot name
      * @param token Bot token
-     * @param data Data source
+     * @param users Users
      */
     public BotApp(final String name,
-        final String token, final DataSource data) {
+        final String token, final Users users) {
         this.name = name;
         this.token = token;
-        this.data = data;
+        this.users = users;
         this.api = new TelegramBotsApi();
     }
 
@@ -89,11 +88,11 @@ public final class BotApp implements Runnable {
                         new TkFork(
                             new FkCommand(
                                 "/notifications",
-                                    new TkNotifications(new PgUsers(this.data))
+                                    new TkNotifications(this.users)
                             ),
                             new FkCallbackQuery(
                                 Pattern.compile("click:notification#(?<tid>[A-Za-z0-9]+)"),
-                                    new TkThread(new PgUsers(this.data))
+                                    new TkThread(this.users)
                             )
                         ),
                         new FbUnauthorized()

--- a/src/main/java/com/g4s8/ghman/bot/BotApp.java
+++ b/src/main/java/com/g4s8/ghman/bot/BotApp.java
@@ -16,6 +16,7 @@
  */
 package com.g4s8.ghman.bot;
 
+import com.g4s8.ghman.data.PgUsers;
 import com.g4s8.teletakes.bot.BotSimple;
 import com.g4s8.teletakes.fk.FkCallbackQuery;
 import com.g4s8.teletakes.fk.FkCommand;
@@ -88,11 +89,11 @@ public final class BotApp implements Runnable {
                         new TkFork(
                             new FkCommand(
                                 "/notifications",
-                                    new TkNotifications(this.data)
+                                    new TkNotifications(new PgUsers(this.data))
                             ),
                             new FkCallbackQuery(
                                 Pattern.compile("click:notification#(?<tid>[A-Za-z0-9]+)"),
-                                    new TkThread(this.data)
+                                    new TkThread(new PgUsers(this.data))
                             )
                         ),
                         new FbUnauthorized()

--- a/src/main/java/com/g4s8/ghman/bot/TkNotifications.java
+++ b/src/main/java/com/g4s8/ghman/bot/TkNotifications.java
@@ -42,7 +42,7 @@ import org.telegram.telegrambots.api.objects.Update;
 public final class TkNotifications implements TmTake {
 
     /**
-     * Data source.
+     * Users.
      */
     private final Users users;
 

--- a/src/main/java/com/g4s8/ghman/bot/TkNotifications.java
+++ b/src/main/java/com/g4s8/ghman/bot/TkNotifications.java
@@ -16,9 +16,9 @@
  */
 package com.g4s8.ghman.bot;
 
-import com.g4s8.ghman.data.PgUsers;
 import com.g4s8.ghman.user.GhUser;
 import com.g4s8.ghman.user.Thread;
+import com.g4s8.ghman.user.Users;
 import com.g4s8.teletakes.rs.RsInlineKeyboard;
 import com.g4s8.teletakes.rs.RsText;
 import com.g4s8.teletakes.rs.TmResponse;
@@ -26,7 +26,6 @@ import com.g4s8.teletakes.tk.TmTake;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import javax.sql.DataSource;
 import org.cactoos.list.Mapped;
 import org.cactoos.list.Solid;
 import org.cactoos.map.MapEntry;
@@ -45,19 +44,19 @@ public final class TkNotifications implements TmTake {
     /**
      * Data source.
      */
-    private final DataSource data;
+    private final Users users;
 
     /**
      * Ctor.
-     * @param data Data source
+     * @param users Users
      */
-    public TkNotifications(final DataSource data) {
-        this.data = data;
+    public TkNotifications(final Users users) {
+        this.users = users;
     }
 
     @Override
     public TmResponse act(final Update update) throws IOException {
-        final GhUser user = new PgUsers(this.data).user(update.getMessage().getChat()).github();
+        final GhUser user = this.users.user(update.getMessage().getChat()).github();
         final List<Thread> nts = new Solid<>(user.notifications());
         return new RsInlineKeyboard(
             new RsText(new FormattedText("You have %d unread notifications:", nts.size())),

--- a/src/main/java/com/g4s8/ghman/bot/TkThread.java
+++ b/src/main/java/com/g4s8/ghman/bot/TkThread.java
@@ -46,7 +46,7 @@ import org.telegram.telegrambots.api.objects.Update;
 public final class TkThread implements TmTake {
 
     /**
-     * Data source.
+     * Users.
      */
     private final Users users;
 

--- a/src/main/java/com/g4s8/ghman/bot/TkThread.java
+++ b/src/main/java/com/g4s8/ghman/bot/TkThread.java
@@ -16,10 +16,10 @@
  */
 package com.g4s8.ghman.bot;
 
-import com.g4s8.ghman.data.PgUsers;
 import com.g4s8.ghman.user.GhThread;
 import com.g4s8.ghman.user.GhUser;
 import com.g4s8.ghman.user.ThreadIssue;
+import com.g4s8.ghman.user.Users;
 import com.g4s8.teletakes.rs.RsText;
 import com.g4s8.teletakes.rs.TmResponse;
 import com.g4s8.teletakes.tk.TmTake;
@@ -27,7 +27,6 @@ import com.jcabi.github.Comment;
 import com.jcabi.github.Issue;
 import java.io.IOException;
 import java.util.Date;
-import javax.sql.DataSource;
 import org.cactoos.list.Mapped;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.Joined;
@@ -49,19 +48,19 @@ public final class TkThread implements TmTake {
     /**
      * Data source.
      */
-    private final DataSource data;
+    private final Users users;
 
     /**
      * Ctor.
-     * @param data Data source
+     * @param users Users
      */
-    public TkThread(final DataSource data) {
-        this.data = data;
+    public TkThread(final Users users) {
+        this.users = users;
     }
 
     @Override
     public TmResponse act(final Update update) throws IOException {
-        final GhUser user = new PgUsers(this.data)
+        final GhUser user = this.users
             .user(update.getCallbackQuery().getMessage().getChat())
             .github();
         final GhThread thread = user.thread(update.getCallbackQuery().getData().split("#")[1]);


### PR DESCRIPTION
This is for #45.

As requested in the issue, I'm changing the classes `TkNotifications` and `TkThread` so that they have a `Users` field instead of `DataSource`.
I also had to change their use in `BotApp` to match the new constructors: the `PgUsers` object is now created in `BotApp`.