### PR TITLE
(#40) Replacing String.format with FormattedText

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.41</version>
+      <version>0.42</version>
     </dependency>
     <!-- logging -->
     <dependency>
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.llorllale</groupId>
       <artifactId>cactoos-matchers</artifactId>
-      <version>0.15</version>
+      <version>0.17</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/g4s8/ghman/data/SimpleDataSource.java
+++ b/src/main/java/com/g4s8/ghman/data/SimpleDataSource.java
@@ -23,6 +23,8 @@ import javax.sql.DataSource;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.Solid;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 
 /**
  * Simple data source.
@@ -64,10 +66,10 @@ public final class SimpleDataSource implements Scalar<DataSource> {
         final org.postgresql.jdbc2.optional.SimpleDataSource source =
             new org.postgresql.jdbc2.optional.SimpleDataSource();
         source.setUrl(
-            String.format(
-                "jdbc:postgresql://%s:%s/%s",
+            new FormattedText(
+                new TextOf("jdbc:postgresql://%s:%s/%s"),
                 env.get("DB_HOST"), env.get("DB_PORT"), env.get("DB_NAME")
-            )
+            ).toString()
         );
         source.setUser(env.get("DB_USER"));
         if (env.containsKey("DB_PASSWORD")) {
@@ -92,10 +94,10 @@ public final class SimpleDataSource implements Scalar<DataSource> {
         for (final String var : req) {
             if (!env.containsKey(var)) {
                 throw new IllegalArgumentException(
-                    String.format(
-                        "Environment variable '%s' is required",
+                    new FormattedText(
+                        new TextOf("Environment variable '%s' is required"),
                         var
-                    )
+                    ).toString()
                 );
             }
         }

--- a/src/main/java/com/g4s8/ghman/user/GhUser.java
+++ b/src/main/java/com/g4s8/ghman/user/GhUser.java
@@ -21,6 +21,8 @@ import com.jcabi.http.response.JsonResponse;
 import java.io.IOException;
 import javax.json.JsonValue;
 import org.cactoos.iterable.Mapped;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 
 /**
  * Github user.
@@ -67,7 +69,7 @@ public final class GhUser {
         return new GhThread(
             this.ghb.entry()
                 .uri()
-                .path(String.format("/notifications/threads/%s", tid))
+                .path(new FormattedText(new TextOf("/notifications/threads/%s"), tid).toString())
                 .back()
                 .fetch().as(JsonResponse.class)
                 .json().readObject()

--- a/src/main/java/com/g4s8/ghman/user/ThreadIssue.java
+++ b/src/main/java/com/g4s8/ghman/user/ThreadIssue.java
@@ -33,10 +33,13 @@ import org.cactoos.Scalar;
 import org.cactoos.scalar.IoChecked;
 import org.cactoos.scalar.SolidScalar;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 
 /**
  * Issue for thread.
  * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class ThreadIssue implements Issue {
@@ -58,10 +61,10 @@ public final class ThreadIssue implements Issue {
                 final String type = subj.getString("type");
                 if (!type.equals("Issue")) {
                     throw new UnsupportedThreadException(
-                        String.format(
-                            "Thread subject type is `%s` - not supported yet",
+                        new FormattedText(
+                            new TextOf("Thread subject type is `%s` - not supported yet"),
                             type
-                        )
+                        ).toString()
                     );
                 }
                 // @checkstyle LineLengthCheck (1 line)

--- a/src/main/java/com/g4s8/ghman/web/FkGitHubAuthRedirection.java
+++ b/src/main/java/com/g4s8/ghman/web/FkGitHubAuthRedirection.java
@@ -19,6 +19,8 @@ package com.g4s8.ghman.web;
 import java.io.IOException;
 import org.apache.http.client.utils.URIBuilder;
 import org.cactoos.scalar.IoChecked;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.Take;
@@ -30,8 +32,6 @@ import org.takes.rs.RsRedirect;
 /**
  * Github Authorization Redirection.
  * @since 1.0
- * @todo #4:30min Replace the call to static method String.format
- *  with the use of cactoos' text.Formatted class in all files.
  * @todo #4:30min Implement unit tests for FkGitHubAuthRedirection. Refer
  *  to takes framework Unit testing guide @ https://github.com/yegor256/takes#unit-testing
  */
@@ -48,7 +48,9 @@ public final class FkGitHubAuthRedirection extends FkWrap {
                         () -> new URIBuilder("https://github.com/login/oauth/authorize")
                             .addParameter(
                                 "redirect_uri",
-                                String.format("https://%s/auth", System.getenv("APP_HOST"))
+                                new FormattedText(
+                                    new TextOf("https://%s/auth"), System.getenv("APP_HOST")
+                                ).toString()
                             )
                             .addParameter("client_id", System.getenv("GH_CLIENT"))
                             .addParameter("scope", "notifications")

--- a/src/main/java/com/g4s8/ghman/web/PsUserById.java
+++ b/src/main/java/com/g4s8/ghman/web/PsUserById.java
@@ -17,6 +17,8 @@
 package com.g4s8.ghman.web;
 
 import java.io.IOException;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 import org.takes.Request;
 import org.takes.Response;
 import org.takes.facets.auth.Identity;
@@ -56,7 +58,9 @@ final class PsUserById implements Pass {
     public Opt<Identity> enter(final Request req) throws IOException {
         return new Opt.Single<>(
             new Identity.Simple(
-                String.format("urn:uid:%s", new RqHref.Smart(req).single(this.flag))
+                new FormattedText(
+                    new TextOf("urn:uid:%s"), new RqHref.Smart(req).single(this.flag)
+                ).toString()
             )
         );
     }

--- a/src/test/java/com/g4s8/ghman/bot/TkCloseIssueTest.java
+++ b/src/test/java/com/g4s8/ghman/bot/TkCloseIssueTest.java
@@ -21,6 +21,8 @@ import com.jcabi.github.Repos;
 import com.jcabi.github.mock.MkGithub;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.TextOf;
 import org.junit.jupiter.api.Test;
 import org.llorllale.cactoos.matchers.Assertion;
 import org.llorllale.cactoos.matchers.Throws;
@@ -32,6 +34,7 @@ import org.telegram.telegrambots.api.objects.Update;
 /**
  * Test for {@link TkCloseIssue}.
  * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class TkCloseIssueTest {
 
@@ -46,9 +49,9 @@ final class TkCloseIssueTest {
             .issues().create("illuminate traffic", "");
         Mockito.when(clbq.getMessage()).thenReturn(Mockito.mock(Message.class));
         Mockito.when(clbq.getData()).thenReturn(
-            String.format(
+            new FormattedText(
                 "click:notification.close?repo=%s/%s&issue=%d", user, repo, 1
-            )
+            ).toString()
         );
         Mockito.when(upd.getCallbackQuery()).thenReturn(clbq);
         new Assertion<>(
@@ -71,7 +74,7 @@ final class TkCloseIssueTest {
             "Should throw IllegalArgumentException",
             () -> new TkCloseIssue(new Users.Fake(new MkGithub())).act(upd),
             new Throws<>(
-                String.format("Illegal request: %s", data),
+                new FormattedText(new TextOf("Illegal request: %s"), data).toString(),
                 IllegalArgumentException.class
             )
         ).affirm();


### PR DESCRIPTION
This is for #40.

I replaced every use of `String.format` with `FormattedText` as requested in the issue.
I bumped versions of cactoos and cactoos-matchers to use the unchecked `toString` method for `FormattedText`.