### PR TITLE
(#36) Distribute BotApp responsibilty in two classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>com.g4s8</groupId>
       <artifactId>teletakes</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.2</version>
     </dependency>
     <!-- testing -->
     <dependency>

--- a/src/main/java/com/g4s8/ghman/App.java
+++ b/src/main/java/com/g4s8/ghman/App.java
@@ -17,6 +17,7 @@
 package com.g4s8.ghman;
 
 import com.g4s8.ghman.bot.BotApp;
+import com.g4s8.ghman.bot.GhBot;
 import com.g4s8.ghman.data.FlywayDataSource;
 import com.g4s8.ghman.data.PgUsers;
 import com.g4s8.ghman.data.SimpleDataSource;
@@ -65,10 +66,10 @@ public final class App {
         final Thread bot = new Thread(
             new VerboseRunnable(
                 new BotApp(
-                    System.getenv("TG_NAME"),
-                    System.getenv("TG_TOKEN"),
-                    new PgUsers(data),
-                    new EnvironmentVariables()
+                    new GhBot(
+                        new PgUsers(data),
+                        new EnvironmentVariables()
+                    )
                 )
             )
         );

--- a/src/main/java/com/g4s8/ghman/bot/BotApp.java
+++ b/src/main/java/com/g4s8/ghman/bot/BotApp.java
@@ -28,12 +28,6 @@ import org.telegram.telegrambots.generics.LongPollingBot;
  * Telegram bot entry point.
  *
  * @since 1.0
- * @todo #11:30mins Patterns in callback queries chains are distributed in
- *  multiple classes: for example, pattern for close issue is given here and in
- *  TkCloseIssue. Find a way to avoid this by maybe having string pattern
- *  representation here and passing Matcher to telegram takes (TkCloseIssue) or
- *  by having one class implementing Fork and containing both the current code
- *  of TkCloseIssue and the creation of the FkCallbackQuery.
  */
 public final class BotApp implements Runnable {
 

--- a/src/main/java/com/g4s8/ghman/bot/BotApp.java
+++ b/src/main/java/com/g4s8/ghman/bot/BotApp.java
@@ -16,36 +16,25 @@
  */
 package com.g4s8.ghman.bot;
 
-import com.g4s8.ghman.env.EnvironmentVariables;
-import com.g4s8.ghman.user.Users;
-import com.g4s8.teletakes.bot.BotSimple;
-import com.g4s8.teletakes.fk.FkCallbackQuery;
-import com.g4s8.teletakes.fk.FkCommand;
-import com.g4s8.teletakes.tk.TkFallback;
-import com.g4s8.teletakes.tk.TkFork;
 import com.jcabi.aspects.Tv;
 import com.jcabi.log.Logger;
-import java.util.regex.Pattern;
 import org.telegram.telegrambots.ApiContextInitializer;
 import org.telegram.telegrambots.TelegramBotsApi;
 import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
 import org.telegram.telegrambots.generics.BotSession;
+import org.telegram.telegrambots.generics.LongPollingBot;
 
 /**
  * Telegram bot entry point.
  *
  * @since 1.0
- * @todo #2:30mins Fix the ClassDataAbstractionCouplingCheck & PMD rule
- *  exclusions in BotApp class
  * @todo #11:30mins Patterns in callback queries chains are distributed in
  *  multiple classes: for example, pattern for close issue is given here and in
  *  TkCloseIssue. Find a way to avoid this by maybe having string pattern
  *  representation here and passing Matcher to telegram takes (TkCloseIssue) or
  *  by having one class implementing Fork and containing both the current code
  *  of TkCloseIssue and the creation of the FkCallbackQuery.
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.UnnecessaryFullyQualifiedName")
 public final class BotApp implements Runnable {
 
     static {
@@ -53,14 +42,9 @@ public final class BotApp implements Runnable {
     }
 
     /**
-     * Bot name.
+     * Bot.
      */
-    private final String name;
-
-    /**
-     * Bot token.
-     */
-    private final String token;
+    private final LongPollingBot bot;
 
     /**
      * Bot API.
@@ -68,65 +52,24 @@ public final class BotApp implements Runnable {
     private final TelegramBotsApi api;
 
     /**
-     * Users.
-     */
-    private final Users users;
-
-    /**
-     * Environment.
-     */
-    private final EnvironmentVariables env;
-
-    /**
      * Ctor.
-     * @param name Bot name
-     * @param token Bot token
-     * @param users Users
-     * @param env Environment
-     * @checkstyle ParameterNumberCheck (3 lines)
+     * @param bot Bot
      */
-    public BotApp(final String name, final String token, final Users users,
-        final EnvironmentVariables env) {
-        this.name = name;
-        this.token = token;
-        this.users = users;
+    public BotApp(final LongPollingBot bot) {
+        this.bot = bot;
         this.api = new TelegramBotsApi();
-        this.env = env;
     }
 
     @Override
     public void run() {
         try {
-            final BotSimple bot = new BotSimple(
-                new TkMarkdown(
-                    new TkFallback(
-                        new TkFork(
-                            new FkCommand(
-                                "/notifications",
-                                    new TkNotifications(this.users)
-                            ),
-                            new FkCallbackQuery(
-                                Pattern.compile("click:notification#(?<tid>[A-Za-z0-9]+)"),
-                                new TkThread(this.users)
-                            ),
-                            new FkCallbackQuery(
-                                //@checkstyle LineLengthCheck (1 line)
-                                Pattern.compile("click:notification.close\\?repo=(?<coords>.+/.+)&issue=(?<issue>\\d+)"),
-                                new TkCloseIssue(this.users)
-                            )
-                        ),
-                        new FbUnauthorized(this.env)
-                    )
-                ),
-                this.name, this.token
-            );
-            final BotSession session = this.api.registerBot(bot);
-            Logger.info(this, "Bot %s has been started", this.name);
-            while (!java.lang.Thread.currentThread().isInterrupted()) {
+            final BotSession session = this.api.registerBot(this.bot);
+            Logger.info(this, "Bot %s has been started", this.bot);
+            while (!Thread.currentThread().isInterrupted()) {
                 try {
-                    java.lang.Thread.sleep(Tv.TEN);
+                    Thread.sleep(Tv.TEN);
                 } catch (final InterruptedException ignore) {
-                    java.lang.Thread.currentThread().interrupt();
+                    Thread.currentThread().interrupt();
                 }
             }
             session.stop();

--- a/src/main/java/com/g4s8/ghman/bot/GhBot.java
+++ b/src/main/java/com/g4s8/ghman/bot/GhBot.java
@@ -36,6 +36,12 @@ import org.telegram.telegrambots.generics.LongPollingBot;
  * GhMan Bot.
  *
  * @since 1.0
+ * @todo #11:30mins Patterns in callback queries chains are distributed in
+ *  multiple classes: for example, pattern for close issue is given here and in
+ *  TkCloseIssue. Find a way to avoid this by maybe having string pattern
+ *  representation here and passing Matcher to telegram takes (TkCloseIssue) or
+ *  by having one class implementing Fork and containing both the current code
+ *  of TkCloseIssue and the creation of the FkCallbackQuery.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class GhBot implements Bot, LongPollingBot {

--- a/src/main/java/com/g4s8/ghman/bot/GhBot.java
+++ b/src/main/java/com/g4s8/ghman/bot/GhBot.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019 Kirill Ch. (g4s8.publci@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.g4s8.ghman.bot;
+
+import com.g4s8.ghman.env.EnvironmentVariables;
+import com.g4s8.ghman.user.Users;
+import com.g4s8.teletakes.bot.Bot;
+import com.g4s8.teletakes.bot.BotSimple;
+import com.g4s8.teletakes.fk.FkCallbackQuery;
+import com.g4s8.teletakes.fk.FkCommand;
+import com.g4s8.teletakes.tk.TkFallback;
+import com.g4s8.teletakes.tk.TkFork;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.telegram.telegrambots.api.methods.send.SendMessage;
+import org.telegram.telegrambots.api.objects.Update;
+import org.telegram.telegrambots.exceptions.TelegramApiRequestException;
+import org.telegram.telegrambots.generics.BotOptions;
+import org.telegram.telegrambots.generics.LongPollingBot;
+
+/**
+ * GhMan Bot.
+ *
+ * @since 1.0
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+public final class GhBot implements Bot, LongPollingBot {
+
+    /**
+     * Bot.
+     */
+    private final BotSimple bot;
+
+    /**
+     * Ctor.
+     * @param users Users.
+     * @param env Environment.
+     */
+    public GhBot(final Users users, final EnvironmentVariables env) {
+        this.bot = new BotSimple(
+            new TkMarkdown(
+                new TkFallback(
+                    new TkFork(
+                        new FkCommand(
+                            "/notifications",
+                            new TkNotifications(users)
+                        ),
+                        new FkCallbackQuery(
+                            Pattern.compile(
+                                "click:notification#(?<tid>[A-Za-z0-9]+)"
+                            ),
+                            new TkThread(users)
+                        ),
+                        new FkCallbackQuery(
+                            Pattern.compile(
+                                //@checkstyle LineLengthCheck (1 line)
+                                "click:notification.close\\?repo=(?<coords>.+/.+)&issue=(?<issue>\\d+)"
+                            ),
+                            new TkCloseIssue(users)
+                        )
+                    ),
+                    new FbUnauthorized(env)
+                )
+            ),
+            env.botUsername(),
+            env.botToken()
+        );
+    }
+
+    @Override
+    public String toString() {
+        return this.getBotUsername();
+    }
+
+    @Override
+    public void onUpdateReceived(final Update update) {
+        this.bot.onUpdateReceived(update);
+    }
+
+    @Override
+    public String getBotUsername() {
+        return this.bot.getBotUsername();
+    }
+
+    @Override
+    public String getBotToken() {
+        return this.bot.getBotToken();
+    }
+
+    @Override
+    public BotOptions getOptions() {
+        return this.bot.getOptions();
+    }
+
+    @Override
+    public void clearWebhook() throws TelegramApiRequestException {
+        this.bot.clearWebhook();
+    }
+
+    @Override
+    public void send(final SendMessage msg) throws IOException {
+        this.bot.send(msg);
+    }
+}

--- a/src/main/java/com/g4s8/ghman/env/EnvironmentVariables.java
+++ b/src/main/java/com/g4s8/ghman/env/EnvironmentVariables.java
@@ -42,6 +42,16 @@ public final class EnvironmentVariables {
     private static final String APP_HOST = "APP_HOST";
 
     /**
+     * Bot username Key String.
+     */
+    private static final String TG_NAME = "TG_NAME";
+
+    /**
+     * Bot token Key String.
+     */
+    private static final String TG_TOKEN = "TG_TOKEN";
+
+    /**
      * Environment Variables Map.
      */
     private final Map<String, String> envvars;
@@ -69,7 +79,7 @@ public final class EnvironmentVariables {
      */
     public String githubClientId() throws IllegalStateException {
         return this.envvars.computeIfAbsent(
-            this.GH_CLIENT,
+            EnvironmentVariables.GH_CLIENT,
             this::missingKeyExceptionThrower
         );
     }
@@ -82,7 +92,7 @@ public final class EnvironmentVariables {
      */
     public String githubClientSecret() throws IllegalStateException {
         return this.envvars.computeIfAbsent(
-            this.GH_SECRET,
+            EnvironmentVariables.GH_SECRET,
             this::missingKeyExceptionThrower
         );
     }
@@ -95,7 +105,33 @@ public final class EnvironmentVariables {
      */
     public String applicationHost() throws IllegalStateException {
         return this.envvars.computeIfAbsent(
-            this.APP_HOST,
+            EnvironmentVariables.APP_HOST,
+            this::missingKeyExceptionThrower
+        );
+    }
+
+    /**
+     * Retrieve Bot username.
+     * @return Bot username
+     * @throws IllegalStateException if bot username is missing from
+     *  system environment variables.
+     */
+    public String botUsername() throws IllegalStateException {
+        return this.envvars.computeIfAbsent(
+            EnvironmentVariables.TG_NAME,
+            this::missingKeyExceptionThrower
+        );
+    }
+
+    /**
+     * Retrieve Bot token.
+     * @return Bot token
+     * @throws IllegalStateException if bot token is missing from
+     *  system environment variables.
+     */
+    public String botToken() throws IllegalStateException {
+        return this.envvars.computeIfAbsent(
+            EnvironmentVariables.TG_TOKEN,
             this::missingKeyExceptionThrower
         );
     }

--- a/src/test/java/com/g4s8/ghman/env/EnvironmentVariablesTest.java
+++ b/src/test/java/com/g4s8/ghman/env/EnvironmentVariablesTest.java
@@ -46,6 +46,16 @@ public final class EnvironmentVariablesTest {
     private static final String APP_HOST = "HOST";
 
     /**
+     * Bot username Key String.
+     */
+    private static final String TG_NAME = "NAME";
+
+    /**
+     * Bot token Key String.
+     */
+    private static final String TG_TOKEN = "TOKEN";
+
+    /**
      * Environment Variables Key/Value Map.
      */
     private final Map<String, String> validvarmap = new HashMap<>();
@@ -55,6 +65,8 @@ public final class EnvironmentVariablesTest {
         this.validvarmap.put("GH_CLIENT", EnvironmentVariablesTest.CLIENT_ID);
         this.validvarmap.put("GH_SECRET", EnvironmentVariablesTest.SECRET);
         this.validvarmap.put("APP_HOST", EnvironmentVariablesTest.APP_HOST);
+        this.validvarmap.put("TG_NAME", EnvironmentVariablesTest.TG_NAME);
+        this.validvarmap.put("TG_TOKEN", EnvironmentVariablesTest.TG_TOKEN);
     }
 
     @Test
@@ -81,6 +93,24 @@ public final class EnvironmentVariablesTest {
             "Failed to get Application Host value from environment variables",
             new EnvironmentVariables(this.validvarmap).applicationHost(),
             new IsEqual<>(EnvironmentVariablesTest.APP_HOST)
+        ).affirm();
+    }
+
+    @Test
+    void shouldReturnTgNameValue() {
+        new Assertion<>(
+            "must get bot username value from environment variables",
+            new EnvironmentVariables(this.validvarmap).botUsername(),
+            new IsEqual<>(EnvironmentVariablesTest.TG_NAME)
+        ).affirm();
+    }
+
+    @Test
+    void shouldReturnTgTokenValue() {
+        new Assertion<>(
+            "must get bot token value from environment variables",
+            new EnvironmentVariables(this.validvarmap).botToken(),
+            new IsEqual<>(EnvironmentVariablesTest.TG_TOKEN)
         ).affirm();
     }
 }


### PR DESCRIPTION
This is for #36 

I've removed as much exclusions as possible while also separating the two responsibilities of `BotApp` in their respective classes.

Note that the very nature of `GhBot` makes it impossible to have a low `ClassDataAbstractionCoupling`. I don't think it is possible, and I'm even questioning the validity of this check, half of the classes of ghman are ignoring it.