### PR TITLE
(#35) Distribute TkThread responsibility in multiple classes

### DIFF
--- a/src/main/java/com/g4s8/ghman/bot/ThreadIssueButtons.java
+++ b/src/main/java/com/g4s8/ghman/bot/ThreadIssueButtons.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019 Kirill Ch. (g4s8.publci@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.g4s8.ghman.bot;
+
+import com.jcabi.github.Issue;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapEnvelope;
+import org.cactoos.map.MapOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.UncheckedText;
+
+/**
+ * Telegram buttons to act on an {@link Issue}.
+ *
+ * @since 1.0
+ * @todo #35:30min Implement Unit tests for this class
+ *  using junit, cactoos-matchers and fake class (no mocks).
+ */
+public final class ThreadIssueButtons extends MapEnvelope<String, String> {
+    /**
+     * Ctor.
+     * @param issue Issue
+     */
+    public ThreadIssueButtons(final Issue issue) {
+        this(new Issue.Smart(issue));
+    }
+
+    /**
+     * Ctor.
+     * @param issue Issue
+     */
+    public ThreadIssueButtons(final Issue.Smart issue) {
+        super(() -> new MapOf<>(
+            new MapEntry<>(
+                "close",
+                new UncheckedText(
+                    new FormattedText(
+                        "click:notification.close?repo=%s&issue=%d",
+                        issue.repo().coordinates(), issue.number()
+                    )
+                ).asString()
+            )
+        ));
+    }
+}

--- a/src/main/java/com/g4s8/ghman/bot/ThreadIssueButtons.java
+++ b/src/main/java/com/g4s8/ghman/bot/ThreadIssueButtons.java
@@ -31,6 +31,7 @@ import org.cactoos.text.UncheckedText;
  *  using junit, cactoos-matchers and fake class (no mocks).
  */
 public final class ThreadIssueButtons extends MapEnvelope<String, String> {
+
     /**
      * Ctor.
      * @param issue Issue

--- a/src/main/java/com/g4s8/ghman/bot/ThreadIssueText.java
+++ b/src/main/java/com/g4s8/ghman/bot/ThreadIssueText.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Kirill Ch. (g4s8.publci@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.g4s8.ghman.bot;
+
+import com.jcabi.github.Comment;
+import com.jcabi.github.Issue;
+import java.io.IOException;
+import java.util.Date;
+import org.cactoos.list.Mapped;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.Joined;
+import org.cactoos.text.TextEnvelope;
+import org.cactoos.text.TextOf;
+
+/**
+ * Telegram bot notifications text with latest comments.
+ *
+ * @since 1.0
+ * @todo #35:30min Implement Unit tests for this class
+ *  use junit, cactoos-matchers and fake class (no mocks).
+ */
+public final class ThreadIssueText extends TextEnvelope {
+
+    /**
+     * Ctor.
+     * @param issue Issue
+     * @param since Last time comments were seen in milliseconds
+     * @throws IOException If some field can't be read from issue
+     */
+    public ThreadIssueText(final Issue.Smart issue, final long since) throws IOException {
+        this(issue, new Date(since));
+    }
+
+    /**
+     * Ctor.
+     * @param issue Issue
+     * @param since Last time comments were seen
+     * @throws IOException If some field can't be read from issue
+     */
+    public ThreadIssueText(final Issue.Smart issue, final Date since) throws IOException {
+        super(
+            new FormattedText(
+                "[#%d](%s) - %s\n\n%s",
+                issue.number(),
+                new FormattedText(
+                    "https://github.com/%s/issues/%d",
+                    issue.repo().coordinates(),
+                    issue.number()
+                ),
+                issue.title(),
+                new Joined(
+                    new TextOf("\n\n"),
+                    new Mapped<>(
+                        cmt -> new FormattedText(
+                            "[@%s](https://github.com/%s) > %s",
+                            cmt.author().login(),
+                            cmt.author().login(),
+                            cmt.body()
+                        ),
+                        new Mapped<>(
+                            Comment.Smart::new,
+                            issue.comments().iterate(since)
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/src/main/java/com/g4s8/ghman/bot/ThreadIssueText.java
+++ b/src/main/java/com/g4s8/ghman/bot/ThreadIssueText.java
@@ -30,7 +30,7 @@ import org.cactoos.text.TextOf;
  * Telegram bot notifications text with latest comments.
  *
  * @since 1.0
- * @todo #35:30min Implement Unit tests for this class
+ * @todo #35:30min Implement Unit tests for this class,
  *  use junit, cactoos-matchers and fake class (no mocks).
  */
 public final class ThreadIssueText extends TextEnvelope {

--- a/src/main/java/com/g4s8/ghman/bot/TkThread.java
+++ b/src/main/java/com/g4s8/ghman/bot/TkThread.java
@@ -24,19 +24,9 @@ import com.g4s8.teletakes.rs.RsInlineKeyboard;
 import com.g4s8.teletakes.rs.RsText;
 import com.g4s8.teletakes.rs.TmResponse;
 import com.g4s8.teletakes.tk.TmTake;
-import com.jcabi.github.Comment;
 import com.jcabi.github.Issue;
 import java.io.IOException;
-import java.util.Date;
 import org.cactoos.iterable.IterableOf;
-import org.cactoos.list.Mapped;
-import org.cactoos.map.MapEntry;
-import org.cactoos.scalar.Ternary;
-import org.cactoos.scalar.Unchecked;
-import org.cactoos.text.FormattedText;
-import org.cactoos.text.Joined;
-import org.cactoos.text.TextOf;
-import org.cactoos.text.UncheckedText;
 import org.telegram.telegrambots.api.objects.Update;
 
 /**
@@ -45,9 +35,6 @@ import org.telegram.telegrambots.api.objects.Update;
  * @since 1.0
  * @todo #2:30min Implement Unit tests for TkThread class
  *  *  use JUNIT and cactoos-matchers wrapper.
- * @todo #2:30min Fix the ClassDataAbstractionCouplingCheck rule exclusion
- *  in TkThread class. This class is too complex.
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class TkThread implements TmTake {
 
@@ -72,59 +59,18 @@ public final class TkThread implements TmTake {
         final GhThread thread = user.thread(
             update.getCallbackQuery().getData().split("#")[1]
         );
-        final Issue issue = new ThreadIssue(user.github(), thread);
-        final Issue.Smart smart = new Issue.Smart(issue);
-        final TmResponse text = new RsText(
-            new FormattedText(
-                "[#%d](%s) - %s\n\n%s",
-                issue.number(),
-                new FormattedText(
-                    "https://github.com/%s/issues/%d",
-                    issue.repo().coordinates(),
-                    issue.number()
-                ).toString(),
-                smart.title(),
-                new Joined(
-                    new TextOf("\n\n"),
-                    new Mapped<>(
-                        cmt -> new FormattedText(
-                            "[@%s](https://github.com/%s) > %s",
-                            cmt.author().login(),
-                            cmt.author().login(),
-                            cmt.body()
-                        ),
-                        new Mapped<>(
-                            Comment.Smart::new,
-                            issue.comments().iterate(
-                                new Date(thread.lastRead().toEpochMilli())
-                            )
-                        )
-                    )
-                )
-            )
+        final Issue.Smart issue = new Issue.Smart(
+            new ThreadIssue(user.github(), thread)
         );
-        return new Unchecked<>(
-            new Ternary<>(
-                () -> smart.isOpen()
-                    && smart.author().equals(user.github().users().self()),
-                new RsInlineKeyboard(
-                    text,
-                    new IterableOf<>(
-                        new IterableOf<>(
-                            new MapEntry<>(
-                                "close",
-                                new UncheckedText(
-                                    new FormattedText(
-                                        "click:notification.close?repo=%s&issue=%d",
-                                        issue.repo().coordinates(), issue.number()
-                                    )
-                                ).asString()
-                            )
-                        )
-                    )
-                ),
-                text
-            )
-        ).value();
+        TmResponse res = new RsText(
+            new ThreadIssueText(issue, thread.lastRead().toEpochMilli())
+        );
+        if (issue.isOpen() && issue.author().equals(user.github().users().self())) {
+            res = new RsInlineKeyboard(
+                res,
+                new IterableOf<>(new ThreadIssueButtons(issue).entrySet())
+            );
+        }
+        return res;
     }
 }


### PR DESCRIPTION
This is for #35 

By distributing the various responsibility of `TkThread` in multiple class, this will ease testing and prevent us from using checkstyle exclusions.