### PR TITLE
#55 - Removed Integer.parseInt, made code more readable

### DIFF
--- a/src/main/java/com/g4s8/ghman/bot/TkCloseIssue.java
+++ b/src/main/java/com/g4s8/ghman/bot/TkCloseIssue.java
@@ -16,15 +16,18 @@
  */
 package com.g4s8.ghman.bot;
 
+import com.g4s8.ghman.user.GhUser;
 import com.g4s8.ghman.user.Users;
 import com.g4s8.teletakes.rs.RsText;
 import com.g4s8.teletakes.rs.TmResponse;
 import com.g4s8.teletakes.tk.TmTake;
 import com.jcabi.github.Coordinates;
 import com.jcabi.github.Issue;
+import com.jcabi.github.Repo;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.cactoos.scalar.NumberOf;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.UncheckedText;
 import org.telegram.telegrambots.api.objects.Update;
@@ -32,11 +35,6 @@ import org.telegram.telegrambots.api.objects.Update;
 /**
  * Telegram take to close issue.
  * @since 1.0
- * @todo #11:30mins 1) find a way to avoid using static method Integer.parseInt()
- *  2) there too much method chaining in Issue.Smart() instance creation. It's
- *  hard to read and not very good in term of OO practice: we depend here on
- *  many objects and we want to promote loose coupling usually. Find a way to
- *  avoid it.
  */
 public final class TkCloseIssue implements TmTake {
 
@@ -72,14 +70,14 @@ public final class TkCloseIssue implements TmTake {
                 ).asString()
             );
         }
+        final GhUser user = this.users.user(
+            upd.getCallbackQuery().getMessage().getChat()
+        ).github();
+        final Repo repo = user.github().repos().get(
+            new Coordinates.Simple(matcher.group("coords"))
+        );
         new Issue.Smart(
-            this.users.user(
-                upd.getCallbackQuery().getMessage().getChat()
-            )
-            .github().github().repos().get(
-                new Coordinates.Simple(matcher.group("coords"))
-            )
-            .issues().get(Integer.parseInt(matcher.group("issue")))
+            repo.issues().get(new NumberOf(matcher.group("issue")).intValue())
         ).close();
         return new RsText("Issue closed");
     }

--- a/src/main/java/com/g4s8/ghman/user/ThreadIssue.java
+++ b/src/main/java/com/g4s8/ghman/user/ThreadIssue.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 import javax.json.JsonObject;
 import org.cactoos.Scalar;
 import org.cactoos.scalar.IoChecked;
+import org.cactoos.scalar.NumberOf;
 import org.cactoos.scalar.SolidScalar;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
@@ -76,7 +77,7 @@ public final class ThreadIssue implements Issue {
                 }
                 return ghb.repos()
                     .get(new Coordinates.Simple(matcher.group("coords")))
-                    .issues().get(Integer.parseInt(matcher.group("num")));
+                    .issues().get(new NumberOf(matcher.group("num")).intValue());
             }
         );
     }


### PR DESCRIPTION
This is for #55.

1. I removed `Integer.parseInt` as requested and replaced with `NumberOf`. There was another occurrence of this static method in `ThreadIssue.java`, since even a 30 minutes puzzle seemed too much for it I've taken the liberty of replacing the method there as well.

2. I did not find a way to reduce coupling in the construction of `Issue.Smart`, I think that some of the necessary improvements for doing that belong in jcabi and we don't have much room in ghman only. For the moment, I just made the code more readable by separating some declarations from the constructor call (I used `TkNotifications` as an example for the user).